### PR TITLE
remove fastjson2 version to fix NPE

### DIFF
--- a/dubbo-fastjson2-client/pom.xml
+++ b/dubbo-fastjson2-client/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>com.alibaba.fastjson2</groupId>
             <artifactId>fastjson2</artifactId>
-            <version>2.0.14</version>
         </dependency>
     </dependencies>
     <build>

--- a/dubbo-fastjson2-server/pom.xml
+++ b/dubbo-fastjson2-server/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>com.alibaba.fastjson2</groupId>
             <artifactId>fastjson2</artifactId>
-            <version>2.0.14</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
current `benchmark` use `2.0.14`, it will cover `dubbo fastjson2 version`.
remove fastjson2 version to fix NPE.